### PR TITLE
Added hook for knex instance destruction when the server exits

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,11 @@ function fastifyKnexJS(fastify, opts, next) {
   try {
     const handler = knex(opts);
     fastify.decorate('knex', handler);
+
+    fastify.addHook('onClose', () => {
+      fastify.knex.destroy();
+    });
+
     next();
   } catch (err) {
     next(err);


### PR DESCRIPTION
Closing the knex connection is helpful when running tests. Added small snippet that listens to the sever close event and destroys the knex connection.